### PR TITLE
Fixed title spelling (ImplicitiCAD -> ImplicitCAD)

### DIFF
--- a/app/views/pages/tutorial.haml
+++ b/app/views/pages/tutorial.haml
@@ -2,7 +2,7 @@
   .index
     .container.enlarged
       :markdown
-        ImplicitiCAD (Extopenscad) Tutorial
+        ImplicitCAD (Extopenscad) Tutorial
         ===================================
         
         This tutorial will teach you how to design objects in ImplicitCAD's extopenscad language. It requires no knowledge of Haskell.


### PR DESCRIPTION
Fixed a spelling error that I found tonight.
